### PR TITLE
fix: respect useDefineForClassFields=false setting

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,9 @@ export default createUnplugin<Options | undefined, false>(
           parser: {
             syntax: isTs ? 'typescript' : 'ecmascript',
           },
-          transform: {},
+          transform: {
+            useDefineForClassFields: compilerOptions.useDefineForClassFields,
+          },
         }
 
         if (compilerOptions.jsx) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,9 +51,7 @@ export default createUnplugin<Options | undefined, false>(
           parser: {
             syntax: isTs ? 'typescript' : 'ecmascript',
           },
-          transform: {
-            useDefineForClassFields: compilerOptions.useDefineForClassFields,
-          },
+          transform: {},
         }
 
         if (compilerOptions.jsx) {
@@ -84,6 +82,10 @@ export default createUnplugin<Options | undefined, false>(
 
         if (compilerOptions.target) {
           jsc.target = compilerOptions.target
+        }
+
+        if (compilerOptions.useDefineForClassFields != null) {
+          jsc.transform.useDefineForClassFields = compilerOptions.useDefineForClassFields
         }
 
         if (options.jsc) {

--- a/test/fixtures/class-fields/class-field.ts
+++ b/test/fixtures/class-fields/class-field.ts
@@ -1,0 +1,3 @@
+export class TestClass {
+  inlineProperty = 'value';
+}

--- a/test/fixtures/class-fields/tsconfig.json
+++ b/test/fixtures/class-fields/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "esnext",
+    "strict": true,
+    "useDefineForClassFields": false
+  }
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -98,39 +98,16 @@ it('useDefineForClassFields=false', async () => {
   const bundle = await rollup({
     input: fixture('class-fields/class-field.ts'),
     plugins: [
-      swc.rollup({
-        tsconfigFile: false,
-        jsc: {
-          transform: {
-            useDefineForClassFields: false,
-          },
-        },
-      }),
-    ],
-  });
-
-  const { output } = await bundle.generate({
-    format: 'esm',
-    dir: fixture('class-fields/dist'),
-  });
-
-  const code = output[0].code;
-  expect(code).toContain("this.inlineProperty = 'value'"); // Ensure inline property is moved to constructor
-});
-
-it('useDefineForClassFields=false from tsconfig', async () => {
-  const bundle = await rollup({
-    input: fixture('class-fields/class-field.ts'),
-    plugins: [
       swc.rollup(),
     ],
-  });
+  })
 
   const { output } = await bundle.generate({
     format: 'esm',
     dir: fixture('class-fields/dist'),
-  });
+  })
 
-  const code = output[0].code;
-  expect(code).toContain("this.inlineProperty = 'value'"); // Ensure inline property is moved to constructor
-});
+  const code = output[0].code
+  // Ensure inline property is moved to constructor
+  expect(code).toContain('this.inlineProperty = \'value\'')
+})

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -93,3 +93,44 @@ it('minify', async () => {
     "
   `)
 })
+
+it('useDefineForClassFields=false', async () => {
+  const bundle = await rollup({
+    input: fixture('class-fields/class-field.ts'),
+    plugins: [
+      swc.rollup({
+        tsconfigFile: false,
+        jsc: {
+          transform: {
+            useDefineForClassFields: false,
+          },
+        },
+      }),
+    ],
+  });
+
+  const { output } = await bundle.generate({
+    format: 'esm',
+    dir: fixture('class-fields/dist'),
+  });
+
+  const code = output[0].code;
+  expect(code).toContain("this.inlineProperty = 'value'"); // Ensure inline property is moved to constructor
+});
+
+it('useDefineForClassFields=false from tsconfig', async () => {
+  const bundle = await rollup({
+    input: fixture('class-fields/class-field.ts'),
+    plugins: [
+      swc.rollup(),
+    ],
+  });
+
+  const { output } = await bundle.generate({
+    format: 'esm',
+    dir: fixture('class-fields/dist'),
+  });
+
+  const code = output[0].code;
+  expect(code).toContain("this.inlineProperty = 'value'"); // Ensure inline property is moved to constructor
+});


### PR DESCRIPTION
### Description

This setting defaults to true, so if not explicitly set to false, it is not propagated to the transformer.

### Linked Issues

https://github.com/vitest-dev/vitest/issues/7805
