### PR TITLE
fix: disable oxc transformer for rolldown-vite compatibility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -108,6 +108,7 @@ export default createUnplugin<Options | undefined, false>(
         config() {
           return {
             esbuild: false,
+            oxc, false,
           }
         },
       },


### PR DESCRIPTION
### Description

  Add `oxc: false` to the Vite config hook to suppress the warning emitted by rolldown-vite.

  rolldown-vite replaces esbuild with Oxc as the default transformer, so `esbuild: false` alone no longer disables the default transformation and causes the following
  warning:

```
  esbuild option is set to false, but oxc option was not set to false. esbuild: false does not have
  effect any more. If you want to disable the default transformation, which is now handled by Oxc, please
  set oxc: false instead.
```

  `esbuild: false` is kept for compatibility with standard Vite.

  ### Linked Issues

  fixes #210
