### PR TITLE
fix: map tsconfig JSX runtime to SWC

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Following SWC options are inferred from `tsconfig.json`:
 - `jsc.transform.react.pragma`: `compilerOptions.jsxFactory`
 - `jsc.transform.react.pragmaFrag`: `compilerOptions.jsxFragmentFactory`
 - `jsc.transform.react.importSource`: `compilerOptions.jsxImportSource`
+- `jsc.transform.react.runtime`: `automatic` for `compilerOptions.jsx: "react-jsx"` or `"react-jsxdev"`; otherwise `classic`
+- `jsc.transform.react.development`: enabled for `compilerOptions.jsx: "react-jsxdev"`
 - `jsc.transform.legacyDecorator`: `compilerOptions.experimentalDecorators`
 - `jsc.transform.decoratorMetadata`: `compilerOptions.emitDecoratorMetadata`
 - `jsc.keepClassNames`: when decorator is enabled, because original class name is required by libs like `type-graphql` to generate correct graphql type

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,10 @@ export default createUnplugin<Options | undefined, false>(
           }
           Object.assign<TransformConfig, TransformConfig>(jsc.transform, {
             react: {
+              runtime: compilerOptions.jsx === 'react-jsx' || compilerOptions.jsx === 'react-jsxdev'
+                ? 'automatic'
+                : 'classic',
+              development: compilerOptions.jsx === 'react-jsxdev' || undefined,
               pragma: compilerOptions.jsxFactory,
               pragmaFrag: compilerOptions.jsxFragmentFactory,
               importSource: compilerOptions.jsxImportSource,

--- a/test/fixtures/jsx-dev-runtime/index.tsx
+++ b/test/fixtures/jsx-dev-runtime/index.tsx
@@ -1,0 +1,1 @@
+export const Probe = () => <div />

--- a/test/fixtures/jsx-dev-runtime/tsconfig.json
+++ b/test/fixtures/jsx-dev-runtime/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsxdev"
+  }
+}

--- a/test/fixtures/jsx-runtime/index.tsx
+++ b/test/fixtures/jsx-runtime/index.tsx
@@ -1,0 +1,1 @@
+export const Probe = () => <div />

--- a/test/fixtures/jsx-runtime/tsconfig.json
+++ b/test/fixtures/jsx-runtime/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  }
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -53,6 +53,38 @@ it('read tsconfig', async () => {
   })).rejects.toThrow('Syntax Error')
 })
 
+it('uses the automatic JSX runtime from tsconfig', async () => {
+  const bundle = await rollup({
+    input: fixture('jsx-runtime/index.tsx'),
+    external: ['react/jsx-runtime'],
+    plugins: [swc.rollup()],
+  })
+
+  const { output } = await bundle.generate({
+    format: 'esm',
+    dir: fixture('jsx-runtime/dist'),
+  })
+
+  expect(output[0].code).toContain('react/jsx-runtime')
+  expect(output[0].code).not.toContain('React.createElement')
+})
+
+it('uses the automatic development JSX runtime from tsconfig', async () => {
+  const bundle = await rollup({
+    input: fixture('jsx-dev-runtime/index.tsx'),
+    external: ['react/jsx-dev-runtime'],
+    plugins: [swc.rollup()],
+  })
+
+  const { output } = await bundle.generate({
+    format: 'esm',
+    dir: fixture('jsx-dev-runtime/dist'),
+  })
+
+  expect(output[0].code).toContain('react/jsx-dev-runtime')
+  expect(output[0].code).not.toContain('React.createElement')
+})
+
 it('custom swcrc', async () => {
   const bundle = await rollup({
     input: fixture('custom-swcrc/index.tsx'),


### PR DESCRIPTION
## Summary
- map `react-jsx` and `react-jsxdev` TypeScript JSX modes to SWC's automatic runtime
- enable SWC development output for `react-jsxdev`
- add Rollup regressions for both JSX runtime modes

Closes #379

## Validation
- `pnpm test --run`
- `pnpm lint`
- `pnpm type-check`
- `pnpm build`
- `git diff --check`